### PR TITLE
Issue_1 Pause button reenabled after more than one starts

### DIFF
--- a/promoduro_winforms/promoduro_winforms/Form1.cs
+++ b/promoduro_winforms/promoduro_winforms/Form1.cs
@@ -39,6 +39,8 @@ namespace promoduro_winforms
             starttimer_btn.Enabled = false;
             timetextbox.Enabled = false;
             resettimer_btn.Enabled = false;
+            if (!pause_btn.Enabled)
+                pause_btn.Enabled = true;
 
             // Tick event handling, and timer start
             timer1.Tick += new EventHandler(Timer1_Tick);


### PR DESCRIPTION
Time left  zero or less set the pause button to be grey (correctly - no more time to count down, its over), but it was never _re_enabled. Added a guard.